### PR TITLE
Corregido bug de recibos duplicados en facturas

### DIFF
--- a/Init.php
+++ b/Init.php
@@ -58,6 +58,8 @@ class Init extends InitClass
         $appsettings = $this->toolBox()->appSettings();
         if (empty($appsettings->get('anticipos', 'pdAnticipos'))) {
             $appsettings->set('anticipos', 'pdAnticipos', false);
+        }
+        if (empty($appsettings->get('anticipos', 'level'))) {
             $appsettings->set('anticipos', 'level', 20);
         }
         $appsettings->save();

--- a/Init.php
+++ b/Init.php
@@ -58,6 +58,7 @@ class Init extends InitClass
         $appsettings = $this->toolBox()->appSettings();
         if (empty($appsettings->get('anticipos', 'pdAnticipos'))) {
             $appsettings->set('anticipos', 'pdAnticipos', false);
+            $appsettings->set('anticipos', 'level', 20);
         }
         $appsettings->save();
     }


### PR DESCRIPTION
Localizar bug al generar los recibos de facturas. Parece que en ciertas condiciones está generando más recibos de la cuenta. Cuando un albarán era aprobado creaba la factura con sus recibos, pero si fallaba en la comprobación de los totales por los decimales creaba recibos duplicados.

[Tarea #985](https://facturascripts.com/roadmap/985)