### PR TITLE
Update anticipos.xml

### DIFF
--- a/Table/anticipos.xml
+++ b/Table/anticipos.xml
@@ -112,6 +112,6 @@
     </constraint>
     <constraint>
         <name>ca_anticipos_users</name>
-        <type>FOREIGN KEY (user) REFERENCES users (nick) ON DELETE RESTRICT ON UPDATE CASCADE</type>
+        <type>FOREIGN KEY (user) REFERENCES users (nick) ON DELETE SET NULL ON UPDATE CASCADE</type>
     </constraint>
 </table>


### PR DESCRIPTION
He modificado la restricción sobre el campo usuario para que al eliminar un usuario con anticipos, estos se queden sin usuario, pero no se eliminen.

Ahora mismo con la restricción como está, no se pueden eliminar usuarios que hayan hecho alguna vez un anticipo.